### PR TITLE
remove all uses of Moose::Autobox

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Summary of important user-visible changes for Pod::Weaver::Section::GenerateSect
 -----------------------------------------------------------------------------------
 
 {{$NEXT}}
+  * the use of Moose::Autobox has been removed.
 
 1.01      2013-03-27 01:10:59 Europe/Dublin
   * Introduced option to use no heading with a head value of 0 (zero).

--- a/lib/Pod/Weaver/Section/GenerateSection.pm
+++ b/lib/Pod/Weaver/Section/GenerateSection.pm
@@ -19,7 +19,6 @@ use utf8;
 use strict;
 use warnings;
 use Moose;
-use Moose::Autobox;
 use MooseX::AttributeShortcuts;
 use MooseX::Types::Moose qw(ArrayRef Bool Int Str);
 with (
@@ -169,7 +168,7 @@ sub weave_section {
     return if $input->{zilla}->main_module->name ne $input->{filename};
   }
 
-  my $text = join ("\n", $self->text->flatten);
+  my $text = join ("\n", @{ $self->text });
   if ($self->is_template) {
     $text = $self->fill_in_string($text,
     {
@@ -194,7 +193,7 @@ sub weave_section {
       children => [$text],
     });
   }
-  $document->children->push($text);
+  push @{ $document->children }, $text;
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
autobox no longer builds for perl 5.25.x, so removing its use here will allow for the module to be installed in recent perls and allow for the use of plugin bundles that pull it in.
